### PR TITLE
Fix: Updating greenlet and engineIO to newer versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ eventlet==0.19.0
 Flask==0.11
 Flask-Cors==2.1.2
 Flask-SocketIO==2.4
-greenlet==0.4.9
+greenlet==1.0a1
 gunicorn==19.6.0
 itsdangerous==0.24
 Jinja2==2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gunicorn==19.6.0
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23
-python-engineio==0.9.1
+python-engineio==3.13.2
 python-socketio==1.3
 six==1.10.0
 Werkzeug==0.11.10


### PR DESCRIPTION
This way the installation of dependencies and app launch still work for users with a recent python3 version.